### PR TITLE
Update jpictura.js

### DIFF
--- a/src/js/jpictura.js
+++ b/src/js/jpictura.js
@@ -105,7 +105,7 @@
 
             var image = new Image();
             image.src = $image.attr('src');
-            $(image).load(function () {
+            $(image).on('load', function () {
                 imageLoadedCallback($item, image);
             });
         });
@@ -114,7 +114,7 @@
             var ratio = image.width / image.height;
             setItemWidthHeightRatio($item, ratio);
 
-            if (++loadedImagesCount === $items.size()) {
+            if (++loadedImagesCount === $items.length) {
                 callback($container, $items, options);
             }
         }


### PR DESCRIPTION
With jQuery 3.0 there are no `size()` function, also `.load()` is deprecated - current syntax is `.on('load')`.
I've found your plugin via StackOverflow and it's absolutely awesome enough to keep it updated! :D
Have a good day!

PS No clue about last line, ignore it, nothing has been changed.